### PR TITLE
fix: the server shutdown process now is properly functioning

### DIFF
--- a/src/client/ClientHandler.java
+++ b/src/client/ClientHandler.java
@@ -7,6 +7,7 @@ import java.util.*;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.Condition;
+import java.net.Socket;
 
 import utils.PacketType;
 import utils.LogWriter;
@@ -82,9 +83,31 @@ public class ClientHandler {
                         }
 
                         this.client.shutdownServer();
-                        exited = true;
 
                         this.client.closeConnection();
+
+                        exited = true;
+
+                        /* 
+                           when the server is shutdown, the serverHandler's 
+                           thread that receives that information will interpret 
+                           it and change the server instance's boolean value of
+                           isRunning to true.
+                          
+                           if you go and check the serverMain class, you will see
+                           that the boolean is only checked after a new connection
+                           is accepted. this means that the only way for the 
+                           serverMain class to check if a shutdown was requested 
+                           is to "get out" of the "ss.accept()" line of code. the 
+                           only way to achieve this is to create a new connection
+                           that will be rendered useless by the serverMain class 
+                           as well as the clientHandler class.
+                          
+                           this is why we create a new socket connection to the server
+                        */ 
+                        Socket temp = new Socket("localhost", 8080);
+                        temp.close();
+
                     } catch (InterruptedException e) {
                         e.printStackTrace();
                     } finally {


### PR DESCRIPTION
⚠️ This PR fixes an issue regarding this [PR](https://github.com/2101dudu/Distributed-Remote-Storage/pull/33). 

The implementation in this PR now properly shuts down the server when requested by a client. The previous PR removed a line of code that would make it so that the server would only close the connection when a new client tries to access the server, i.e., client A requests a shutdown and leaves, the server stays on, client B tries to access the server and only then the server shuts down.

The way to work around this is a bit like cheating and was not properly explained, thus resulting in @helderrrg removing the line.